### PR TITLE
Update django to address recent security vunerabiity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keystone-api = "keystone_api.manage:main"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-django = "4.2.5"
+django = "4.2.7"
 django-auth-ldap = "^4.6.0"
 django-celery-beat = "^2.5.0"
 django-celery-results = "^2.5.1"


### PR DESCRIPTION
Updating Django addresses the following vulnerabilities:

- CVE-2023-46695
- CVE-2023-43665