### PR TITLE
Add API health checks to CI

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Run API health checks
         run: |
           docker run --detach -p 8000:8000 test-image
+          sleep 5
+          
           http_status=$(wget -NS localhost:8000/health/ 2>&1 | grep "HTTP/" | awk '{print $2}')
           jq . index.html
           if [ "$http_status" -ne 200 ]; then

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -19,16 +19,10 @@ jobs:
         run: docker load --input /tmp/test-image.tar
 
       - name: Run project checks
-        uses: addnab/docker-run-action@v3
-        with:
-          image: test-image
-          run: check
+        run: docker run test-image check
 
       - name: Run migration checks
-        uses: addnab/docker-run-action@v3
-        with:
-          image: test-image
-          run: makemigrations --check
+        run: docker run test-image makemigrations --check
 
   app-tests:
     name: Application Tests

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run API health checks
         run: |
           docker run --detach -p 8000:8000 test-image
-          curl localhst:8000
+          curl localhost:8000/health
 
   app-tests:
     name: Application Tests

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Load image
         run: docker load --input /tmp/test-image.tar
 
-      - name: Run migration checks
+      - name: Run API health checks
         run: |
-          docker run -p 8000:8000 test-image
+          docker run --detach -p 8000:8000 test-image
           curl localhst:8000
 
   app-tests:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
 
 jobs:
+
+  # System configuration tests including checks for obviously
+  # incorrect settings and missing database migrations
   system-checks:
     name: System Checks
     runs-on: ubuntu-latest
@@ -24,6 +27,8 @@ jobs:
       - name: Run migration checks
         run: docker run test-image makemigrations --check
 
+  # Integration test requiring all API health checks to pass
+  # when launching the docker container with default settings.
   health-checks:
     name: API Health Checks
     runs-on: ubuntu-latest
@@ -41,7 +46,7 @@ jobs:
       - name: Run API health checks
         run: |
           docker run --detach -p 8000:8000 test-image
-          sleep 30
+          sleep 30  # Wait for API server to start
           
           http_status=$(wget -NS localhost:8000/health/ 2>&1 | grep "HTTP/" | awk '{print $2}')
           jq . index.html
@@ -49,6 +54,7 @@ jobs:
             exit 1
           fi
 
+  # Run any/all application tests using the Django `test` utility
   app-tests:
     name: Application Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -22,13 +22,13 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: test-image
-          run: keystone-api check
+          run: check
 
       - name: Run migration checks
         uses: addnab/docker-run-action@v3
         with:
           image: test-image
-          run: keystone-api makemigrations --check
+          run: makemigrations --check
 
   app-tests:
     name: Application Tests

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -24,6 +24,25 @@ jobs:
       - name: Run migration checks
         run: docker run test-image makemigrations --check
 
+  health-checks:
+    name: API Health Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch image artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: test-image
+          path: /tmp
+
+      - name: Load image
+        run: docker load --input /tmp/test-image.tar
+
+      - name: Run migration checks
+        run: |
+          docker run -p 8000:8000 test-image
+          curl localhst:8000
+
   app-tests:
     name: Application Tests
     runs-on: ubuntu-latest
@@ -43,7 +62,7 @@ jobs:
   report-test-status:
     name: Report Test Status
     runs-on: ubuntu-latest
-    needs: [ app-tests, system-checks ]
+    needs: [ app-tests, system-checks, health-checks ]
     if: always()
 
     steps:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run API health checks
         run: |
           docker run --detach -p 8000:8000 test-image
-          sleep 5
+          sleep 30
           
           http_status=$(wget -NS localhost:8000/health/ 2>&1 | grep "HTTP/" | awk '{print $2}')
           jq . index.html

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -41,7 +41,11 @@ jobs:
       - name: Run API health checks
         run: |
           docker run --detach -p 8000:8000 test-image
-          curl localhost:8000/health
+          http_status=$(wget -NS localhost:8000/health/ 2>&1 | grep "HTTP/" | awk '{print $2}')
+          jq . index.html
+          if [ "$http_status" -ne 200 ]; then
+            exit 1
+          fi
 
   app-tests:
     name: Application Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY README.md README.md
 
 # Install the application
 ENV PIP_ROOT_USER_ACTION=ignore
-RUN pip install -e .
+RUN pip install -e . && pip cache purge
 
 # Setup and launch the application
 ENTRYPOINT ["keystone-api"]

--- a/keystone_api/apps/health/views.py
+++ b/keystone_api/apps/health/views.py
@@ -15,6 +15,8 @@ __all__ = ['HealthChecks']
 class HealthChecks(ViewSet, CheckMixin):
     """View for rendering system status messages"""
 
+    permission_classes = []
+
     def list(self, request: HttpRequest, *args, **kwargs) -> JsonResponse:
         """Return a JSON response detailing system status checks.
 


### PR DESCRIPTION
Adds API health checks to the testing CI. This required dropping authentication from the health endpoint, which I was intending to do anyways.