### PR TITLE
Minor update to import statement in test suite

### DIFF
--- a/keystone_api/apps/audit/tests/test_serializers.py
+++ b/keystone_api/apps/audit/tests/test_serializers.py
@@ -3,7 +3,7 @@
 from auditlog.models import LogEntry
 from django.test import TestCase
 
-from keystone_api.apps.audit.serializers import LogEntrySerializer
+from apps.audit.serializers import LogEntrySerializer
 
 
 class LogEntrySerialization(TestCase):


### PR DESCRIPTION
This PR replaces 

`from keystone_api.apps.audit.serializers import LogEntrySerializer`

with

`from apps.audit.serializers import LogEntrySerializer`

Technically both import statements styles will work in the case of the specific files being editted, but that is not true for all cases.  This has to do with how django imports and registers applications. The latter should work in all cases so I'm updating it here for consistency.