### PR TITLE
Adds permissions to allocations/allocations endpoint

### DIFF
--- a/keystone_api/apps/allocations/permissions.py
+++ b/keystone_api/apps/allocations/permissions.py
@@ -8,7 +8,9 @@ predefined access rules.
 
 from rest_framework import permissions
 
-__all__ = ['StaffWriteAuthenticatedRead']
+from .models import RGAffiliatedModel
+
+__all__ = ['StaffWriteAuthenticatedRead', 'StaffWriteGroupRead']
 
 
 class StaffWriteAuthenticatedRead(permissions.BasePermission):
@@ -24,3 +26,27 @@ class StaffWriteAuthenticatedRead(permissions.BasePermission):
             return request.user.is_authenticated
 
         return request.user.is_staff or request.method == 'TRACE'
+
+
+class StaffWriteGroupRead(permissions.BasePermission):
+    """
+    Read access is granted to all users belonging to the same research group
+    as the requested object. Staff users retain all read/write permissions.
+    """
+
+    def has_permission(self, request, view) -> bool:
+        """Return whether the request has permissions to access the requested resource"""
+
+        if request.method in permissions.SAFE_METHODS:
+            return request.user.is_authenticated
+
+        return request.user.is_staff or request.method == 'TRACE'
+
+    def has_object_permission(self, request, view, obj: RGAffiliatedModel) -> bool:
+        """Return whether the incoming HTTP request has permission to access a database record"""
+
+        if request.user.is_staff or request.method == 'TRACE':
+            return True
+
+        user_is_in_group = request.user in obj.get_research_group().get_all_members()
+        return request.method in permissions.SAFE_METHODS and user_is_in_group

--- a/keystone_api/apps/allocations/views.py
+++ b/keystone_api/apps/allocations/views.py
@@ -25,6 +25,7 @@ class ClusterViewSet(viewsets.ModelViewSet):
 class AllocationViewSet(viewsets.ModelViewSet):
     """Manage SU allocations for user research groups."""
 
+    permission_classes = [StaffWriteGroupRead]
     serializer_class = AllocationSerializer
     filterset_fields = '__all__'
 

--- a/keystone_api/tests/allocations/test_allocations.py
+++ b/keystone_api/tests/allocations/test_allocations.py
@@ -1,0 +1,76 @@
+"""Tests for the `allocations` endpoint"""
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.users.models import User
+
+
+class ListEndpointPermissions(APITestCase):
+    """Test user permissions for the `/allocations/allocations/` endpoint
+
+    Endpoint permissions are tested against the following matrix of HTTP responses.
+    All listed responses assume the associated HTTP request is otherwise valid.
+
+    | Authentication      | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
+    |---------------------|-----|------|---------|------|-----|-------|--------|-------|
+    | Anonymous User      | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 405   |
+    | Authenticated User  | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 405   |
+    | Staff User          | 200 | 200  | 200     | 201  | 405 | 405   | 405    | 405   |
+    """
+
+    endpoint = '/allocations/allocations/'
+    valid_post_data = {'sus': 1000, 'cluster': 1, 'proposal': 1}
+    fixtures = ['multi_research_group.yaml']
+
+    def test_anonymous_user_permissions(self) -> None:
+        """Test unauthenticated users are returned a 401 status code for all request types"""
+
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_authenticated_user_permissions(self) -> None:
+        """Test general authenticated users have read-only permissions"""
+
+        user = User.objects.get(username='common_user')
+        self.client.force_authenticate(user=user)
+
+        # Allowed operations
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        # Unauthorized operations
+        self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+        # Disallowed operations
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_staff_user_permissions(self) -> None:
+        """Test staff users have read and write permissions"""
+
+        user = User.objects.get(username='staff_user')
+        self.client.force_authenticate(user=user)
+
+        # Allowed operations
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        post = self.client.post(self.endpoint, data=self.valid_post_data)
+        self.assertEqual(post.status_code, status.HTTP_201_CREATED)
+
+        # Disallowed operations
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/keystone_api/tests/allocations/test_allocations.py
+++ b/keystone_api/tests/allocations/test_allocations.py
@@ -46,7 +46,7 @@ class ListEndpointPermissions(APITestCase):
         self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
         self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
 
-        # Unauthorized operations
+        # Forbidden operations
         self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
@@ -79,14 +79,16 @@ class ListEndpointPermissions(APITestCase):
 class RecordEndpointPermissions(APITestCase):
     """Test user permissions against the `/allocations/allocations/<pk>` endpoint
 
+    Permissions depend on whether the user is a member of the record's associated research group.
+
     Endpoint permissions are tested against the following matrix of HTTP responses.
     All listed responses assume the associated HTTP request is otherwise valid.
 
     | Authentication              | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
     |-----------------------------|-----|------|---------|------|-----|-------|--------|-------|
     | Anonymous User              | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 405   |
-    | User accessing own group    |     |      |         |      |     |       |        | 405   |
-    | User accessing other group  |     |      |         |      |     |       |        | 405   |
+    | User accessing own group    | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 405   |
+    | User accessing other group  | 404 | 404  | 200     | 403  | 403 | 403   | 403    | 405   |
     | Staff User                  | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
     """
 
@@ -99,18 +101,52 @@ class RecordEndpointPermissions(APITestCase):
         endpoint = self.endpoint.format(pk=1)
         self.assertEqual(self.client.get(endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.head(endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.options(endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.post(endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.put(endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.patch(endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.delete(endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertEqual(self.client.options(endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.trace(endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_authenticated_user_same_group(self) -> None:
-        pass
+        """Test permissions for authenticated users accessing records owned by their research group"""
+
+        # Define a user / record endpoint from the SAME research groups
+        endpoint = self.endpoint.format(pk=1)
+        user = User.objects.get(username='user1')
+        self.client.force_authenticate(user=user)
+
+        self.assertEqual(self.client.get(endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(endpoint).status_code, status.HTTP_200_OK)
+
+        # Regular users d nt have write permissions on this endpoint
+        self.assertEqual(self.client.post(endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.put(endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+        self.assertEqual(self.client.trace(endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_authenticated_user_different_group(self) -> None:
-        pass
+        """Test permissions for authenticated users accessing records owned by someone else's research group"""
+
+        # Define a user  / record endpoint from DIFFERENT research groups
+        endpoint = self.endpoint.format(pk=1)
+        user = User.objects.get(username='user2')
+        self.client.force_authenticate(user=user)
+
+        self.assertEqual(self.client.get(endpoint).status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(self.client.head(endpoint).status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(self.client.options(endpoint).status_code, status.HTTP_200_OK)
+
+        # Regular users d nt have write permissions on this endpoint
+        self.assertEqual(self.client.post(endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.put(endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+        self.assertEqual(self.client.trace(endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_staff_user_permissions(self) -> None:
         """Test staff users have read and write permissions"""
@@ -124,6 +160,8 @@ class RecordEndpointPermissions(APITestCase):
         self.assertEqual(self.client.head(endpoint).status_code, status.HTTP_200_OK)
         self.assertEqual(self.client.options(endpoint).status_code, status.HTTP_200_OK)
 
+        self.assertEqual(self.client.post(endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
         put = self.client.put(endpoint, data={'cluster': 1, 'proposal': 1, 'sus': 1000})
         self.assertEqual(put.status_code, status.HTTP_200_OK)
 
@@ -131,7 +169,4 @@ class RecordEndpointPermissions(APITestCase):
         self.assertEqual(patch.status_code, status.HTTP_200_OK)
 
         self.assertEqual(self.client.delete(endpoint).status_code, status.HTTP_204_NO_CONTENT)
-
-        # Disallowed operations
-        self.assertEqual(self.client.post(endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertEqual(self.client.trace(endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/keystone_api/tests/allocations/test_clusters.py
+++ b/keystone_api/tests/allocations/test_clusters.py
@@ -77,7 +77,7 @@ class ListEndpointPermissions(APITestCase):
 
 
 class RecordEndpointPermissions(APITestCase):
-    """Test user permissions against the `/allocations/clusters/` endpoint
+    """Test user permissions against the `/allocations/clusters/<pk>` endpoint
 
     Endpoint permissions are tested against the following matrix of HTTP responses.
     All listed responses assume the associated HTTP request is otherwise valid.
@@ -138,10 +138,10 @@ class RecordEndpointPermissions(APITestCase):
         self.assertEqual(self.client.head(endpoint).status_code, status.HTTP_200_OK)
         self.assertEqual(self.client.options(endpoint).status_code, status.HTTP_200_OK)
 
-        put = self.client.put(endpoint, data={'pk': 1, 'name': 'foo'})
+        put = self.client.put(endpoint, data={'name': 'foo'})
         self.assertEqual(put.status_code, status.HTTP_200_OK)
 
-        patch = self.client.patch(endpoint, data={'pk': 1, 'name': 'foo'})
+        patch = self.client.patch(endpoint, data={'name': 'foo'})
         self.assertEqual(patch.status_code, status.HTTP_200_OK)
 
         self.assertEqual(self.client.delete(endpoint).status_code, status.HTTP_204_NO_CONTENT)

--- a/keystone_api/tests/allocations/test_clusters.py
+++ b/keystone_api/tests/allocations/test_clusters.py
@@ -28,11 +28,11 @@ class ListEndpointPermissions(APITestCase):
 
         self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_authenticated_user_permissions(self) -> None:


### PR DESCRIPTION
Related to #58 

For the general `/allocations/allocations` endpoint:

| Authentication      | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
|---------------------|-----|------|---------|------|-----|-------|--------|-------|
| Anonymous User      | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 405   |
| Authenticated User  | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 405   |
| Staff User          | 200 | 200  | 200     | 201  | 405 | 405   | 405    | 405   |

For a specific record (`/allocations/allocations/<PK>` ):

| Authentication              | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
|-----------------------------|-----|------|---------|------|-----|-------|--------|-------|
| Anonymous User              | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 405   |
| User accessing own group    | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 405   |
| User accessing other group  | 404 | 404  | 200     | 403  | 403 | 403   | 403    | 405   |
| Staff User                  | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |

