### PR TITLE
Adds user permissions to the allocations/proposals endpoint

### DIFF
--- a/keystone_api/apps/allocations/views.py
+++ b/keystone_api/apps/allocations/views.py
@@ -41,6 +41,7 @@ class AllocationViewSet(viewsets.ModelViewSet):
 class ProposalViewSet(viewsets.ModelViewSet):
     """Manage project proposals submitted by users to request additional service unit allocations."""
 
+    permission_classes = [permissions.IsAuthenticated, GroupAdminCreate]
     serializer_class = ProposalSerializer
     filterset_fields = '__all__'
 

--- a/keystone_api/tests/allocations/test_proposals.py
+++ b/keystone_api/tests/allocations/test_proposals.py
@@ -37,7 +37,7 @@ class ListEndpointPermissions(APITestCase):
         self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_non_group_member_permissions(self) -> None:
-        """Test authenticated users have read access but cannot create records for research groups they are not a part of"""
+        """Test users have read access but cannot create records for research groups where they are not members"""
 
         # Record data reflects a group ID for which the user is not a member
         self.client.force_authenticate(user=User.objects.get(username='generic_user'))

--- a/keystone_api/tests/allocations/test_proposals.py
+++ b/keystone_api/tests/allocations/test_proposals.py
@@ -1,0 +1,134 @@
+"""Tests for the `proposals` endpoint"""
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.users.models import User
+
+
+class ListEndpointPermissions(APITestCase):
+    """Test user permissions for the `/allocations/proposals/` endpoint
+
+    Endpoint permissions are tested against the following matrix of HTTP responses.
+    All listed responses assume the associated HTTP request is otherwise valid.
+
+    | Authentication | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
+    |----------------|-----|------|---------|------|-----|-------|--------|-------|
+    | Anonymous User | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 401   |
+    | Non-Member     | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
+    | Group Member   | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
+    | Group Admin    | 200 | 200  | 200     | 201  | 403 | 403   | 403    | 403   |
+    | Group PI       | 200 | 200  | 200     | 201  | 403 | 403   | 403    | 403   |
+    | Staff User     | 200 | 200  | 200     | 201  | 405 | 405   | 405    | 405   |
+    """
+
+    endpoint = '/allocations/proposals/'
+    fixtures = ['multi_research_group.yaml']
+
+    def test_anonymous_user_permissions(self) -> None:
+        """Test unauthenticated users cannot access resources"""
+
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_non_group_member_permissions(self) -> None:
+        """Test authenticated users have read access but cannot create records for research groups they are not a part of"""
+
+        # Record data reflects a group ID for which the user is not a member
+        self.client.force_authenticate(user=User.objects.get(username='generic_user'))
+        record_data = {'title': 'foo', 'description': 'bar', 'group': 1}
+
+        # Allowed operations
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        # Forbidden operations
+        self.assertEqual(self.client.post(self.endpoint, data=record_data).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.put(self.endpoint, data=record_data).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(self.endpoint, data=record_data).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_group_member_permissions(self) -> None:
+        """Test regular research group members have read-only access"""
+
+        # Record data reflects a group ID for which the user is a regular member
+        self.client.force_authenticate(user=User.objects.get(username='member_1'))
+        record_data = {'title': 'foo', 'description': 'bar', 'group': 1}
+
+        # Allowed operations
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        # Forbidden operations
+        self.assertEqual(self.client.post(self.endpoint, data=record_data).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.put(self.endpoint, data=record_data).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(self.endpoint, data=record_data).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_group_admin_permissions(self) -> None:
+        """Test research group admins have read and write access"""
+
+        # Record data reflects a group ID for which the user is an admin
+        self.client.force_authenticate(user=User.objects.get(username='group_admin_1'))
+        record_data = {'title': 'foo', 'description': 'bar', 'group': 1}
+
+        # Allowed operations
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.post(self.endpoint, record_data).status_code, status.HTTP_201_CREATED)
+
+        # Forbidden operations
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_group_pi_permissions(self) -> None:
+        """Test research group PIs have read and write access"""
+
+        # Record data reflects a group ID for which the user is a PI
+        self.client.force_authenticate(user=User.objects.get(username='pi_1'))
+        record_data = {'title': 'foo', 'description': 'bar', 'group': 1}
+
+        # Allowed operations
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.post(self.endpoint, record_data).status_code, status.HTTP_201_CREATED)
+
+        # Forbidden operations
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_user(self) -> None:
+        """Test staff users have read and write permissions"""
+
+        user = User.objects.get(username='staff_user')
+        self.client.force_authenticate(user=user)
+
+        # Allowed operations
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        post = self.client.post(self.endpoint, {'title': 'foo', 'description': 'bar', 'group': 1})
+        self.assertEqual(post.status_code, status.HTTP_201_CREATED)
+
+        # Disallowed operations
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/keystone_api/tests/allocations/test_proposals.py
+++ b/keystone_api/tests/allocations/test_proposals.py
@@ -10,7 +10,6 @@ class ListEndpointPermissions(APITestCase):
     """Test user permissions for the `/allocations/proposals/` endpoint
 
     Endpoint permissions are tested against the following matrix of HTTP responses.
-    All listed responses assume the associated HTTP request is otherwise valid.
 
     | Authentication | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
     |----------------|-----|------|---------|------|-----|-------|--------|-------|
@@ -131,4 +130,117 @@ class ListEndpointPermissions(APITestCase):
         self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
+class RecordEndpointPermissions(APITestCase):
+    """Test user permissions for the `/allocations/proposals/<pk>` endpoint
+
+    Endpoint permissions are tested against the following matrix of HTTP responses.
+
+    | Authentication | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
+    |----------------|-----|------|---------|------|-----|-------|--------|-------|
+    | Anonymous User | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 401   |
+    | Non-Member     | 404 | 404  | 200     | 403  | 403 | 403   | 403    | 403   |
+    | Group Member   | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
+    | Group Admin    | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
+    | Group PI       | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
+    | Staff User     | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |
+    """
+
+    endpoint = '/allocations/proposals/1/'
+    fixtures = ['multi_research_group.yaml']
+
+    def test_anonymous_user_permissions(self) -> None:
+        """Test unauthenticated users cannot access resources"""
+
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_non_group_member_permissions(self) -> None:
+        """Test authenticated users cannot access records for research groups where they are not members"""
+
+        self.client.force_authenticate(user=User.objects.get(username='generic_user'))
+
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_404_NOT_FOUND)
+
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_group_member_permissions(self) -> None:
+        """Test regular research group members have read-only access"""
+
+        self.client.force_authenticate(user=User.objects.get(username='member_1'))
+
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_group_admin_permissions(self) -> None:
+        """Test research group admins have read-only access"""
+
+        self.client.force_authenticate(user=User.objects.get(username='group_admin_1'))
+
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_group_pi_permissions(self) -> None:
+        """Test research group PIs have read-only access"""
+
+        self.client.force_authenticate(user=User.objects.get(username='pi_1'))
+
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        self.assertEqual(self.client.post(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.put(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.patch(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_staff_user(self) -> None:
+        """Test staff users have read and write permissions"""
+
+        user = User.objects.get(username='staff_user')
+        self.client.force_authenticate(user=user)
+        record_data = {'title': 'foo', 'description': 'bar', 'group': 1}
+
+        # Allowed read operations
+        self.assertEqual(self.client.get(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.head(self.endpoint).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.options(self.endpoint).status_code, status.HTTP_200_OK)
+
+        # Allowed write operations
+        self.assertEqual(self.client.post(self.endpoint, record_data).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(self.client.put(self.endpoint, record_data).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.patch(self.endpoint, record_data).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.delete(self.endpoint).status_code, status.HTTP_204_NO_CONTENT)
+
+        # Disallowed operations
         self.assertEqual(self.client.trace(self.endpoint).status_code, status.HTTP_405_METHOD_NOT_ALLOWED)


### PR DESCRIPTION
Progress on #58 

For the list endpoint:

| Authentication | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
|----------------|-----|------|---------|------|-----|-------|--------|-------|
| Anonymous User | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 401   |
| Non-Member     | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
| Group Member   | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
| Group Admin    | 200 | 200  | 200     | 201  | 403 | 403   | 403    | 403   |
| Group PI       | 200 | 200  | 200     | 201  | 403 | 403   | 403    | 403   |
| Staff User     | 200 | 200  | 200     | 201  | 405 | 405   | 405    | 405   |


For the record endpoint:

| Authentication | GET | HEAD | OPTIONS | POST | PUT | PATCH | DELETE | TRACE |
|----------------|-----|------|---------|------|-----|-------|--------|-------|
| Anonymous User | 401 | 401  | 401     | 401  | 401 | 401   | 401    | 401   |
| Non-Member     | 404 | 404  | 200     | 403  | 403 | 403   | 403    | 403   |
| Group Member   | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
| Group Admin    | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
| Group PI       | 200 | 200  | 200     | 403  | 403 | 403   | 403    | 403   |
| Staff User     | 200 | 200  | 200     | 405  | 200 | 200   | 204    | 405   |