### PR TITLE
Replace Celery settings with settings for Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,15 @@ The PostgreSQL backend should always be used in production settings.
 | `DB_HOST`                 | `localhost`              | Database host address (PostgreSQL only).                      |
 | `DB_PORT`                 | `5432`                   | Database host port (PostgreSQL only).                         |
 
-### Celery
+### Redis Connection
 
-Connection settings for Celery backend utilities.
+Connection settings for the Redis backend.
 
-| Setting Name              | Default Value              | Description                                                 |
-|---------------------------|----------------------------|-------------------------------------------------------------|
-| `CELERY_BROKER_URL`       | `redis://127.0.0.1:6379/0` | URL for the Celery message broker.                          |
-| `CELERY_RESULT_BACKEND`   | `redis://127.0.0.1:6379/0` | URL for the Celery result backend.                          |
+| Setting Name              | Default Value            | Description                                                   |
+|---------------------------|--------------------------|---------------------------------------------------------------|
+| `REDIS_HOST`              | `redis://127.0.0.1`      | URL for the Redis message cache.                              |
+| `REDIS_PORT`              | `6379`                   | URL for the Redis message cache.                              |
+| `REDIS_DB`                | `0`                      | The Redis database number to use.                             |
 
 ### Developer Settings
 

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -162,8 +162,9 @@ AUDITLOG_INCLUDE_ALL_MODELS = True
 
 # Celery scheduler
 
-CELERY_BROKER_URL = env.url('CELERY_BROKER_URL', "redis://127.0.0.1:6379/0").geturl()
-CELERY_RESULT_BACKEND = env.url('CELERY_RESULT_BACKEND', "redis://127.0.0.1:6379/0").geturl()
+REDIS_URL = env.url('REDIS_URL', "redis://127.0.0.1:6379").geturl()
+CELERY_BROKER_URL = REDIS_URL.rstrip('/') + '/0'
+CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_CACHE_BACKEND = 'django-cache'
 
 # Database

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -160,10 +160,14 @@ SPECTACULAR_SETTINGS = {
 
 AUDITLOG_INCLUDE_ALL_MODELS = True
 
-# Celery scheduler
+# Redis backend and Celery scheduler
 
-REDIS_URL = env.url('REDIS_URL', "redis://127.0.0.1:6379").geturl()
-CELERY_BROKER_URL = REDIS_URL.rstrip('/') + '/0'
+_redis_host = env.url('REDIS_HOST', 'redis://127.0.0.1').geturl()
+_redis_port = env.int('REDIS_PORT', 6379)
+_redis_db = env.int('REDIS_DB', 0)
+
+REDIS_URL = f'{_redis_host}:{_redis_port}/{_redis_db}'
+CELERY_BROKER_URL = REDIS_URL.rstrip('/') + f'/{_redis_db}'
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_CACHE_BACKEND = 'django-cache'
 

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -166,7 +166,7 @@ _redis_host = env.url('REDIS_HOST', 'redis://127.0.0.1').geturl()
 _redis_port = env.int('REDIS_PORT', 6379)
 _redis_db = env.int('REDIS_DB', 0)
 
-REDIS_URL = f'{_redis_host}:{_redis_port}/{_redis_db}'
+REDIS_URL = f'{_redis_host}:{_redis_port}'
 CELERY_BROKER_URL = REDIS_URL.rstrip('/') + f'/{_redis_db}'
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_CACHE_BACKEND = 'django-cache'


### PR DESCRIPTION
Turns out there is a `REDIS_URL` setting that defaults to `redis://127.0.0.1:6379`. This works fine when deploying the standalone docker container, but won't work in a production environment where backend services have separate DNS names. 

I've exposed the necessary Redis settings using a similar format as the Postgres settings.