### PR TITLE
Fix bug where celery tasks go unregistred

### DIFF
--- a/keystone_api/apps/scheduler/celery.py
+++ b/keystone_api/apps/scheduler/celery.py
@@ -10,4 +10,6 @@ from celery import Celery
 
 celery_app = Celery("scheduler")
 celery_app.config_from_object("django.conf:settings", namespace="CELERY")
-celery_app.autodiscover_tasks()
+celery_app.autodiscover_tasks([
+    'health_check.contrib.celery'
+])


### PR DESCRIPTION
Closes https://github.com/pitt-crc/crc-ops/issues/2

I stumbled across a fix this morning. Looks like the `autodiscover_tasks` method needs to be passed the app names to work properly. I still don't understand why the health check passes when the application stack is run in a single container but not when as distributed services. Either way, looks like this solves the issue.