### PR TITLE
Adds non-privileged user to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ RUN groupadd --gid 900 keystone && \
     useradd -m -u 999 -g keystone keystone && \
     chown keystone:keystone /app
 
-# Setup and laundch the application
+# Setup and launch the application
 ENTRYPOINT ["keystone-api"]
 CMD ["quickstart", "--migrate", "--celery", "--gunicorn", "--no-input"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY README.md README.md
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install -e . && pip cache purge
 
+# Add and unprivliged user for running services
 RUN groupadd --gid 900 keystone && \
     useradd -m -u 999 -g keystone keystone && \
     chown keystone:keystone /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libldap2-dev \
     # Required for celery
     redis \
-  && apt-get clean
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Copy application build files
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11.4-slim
 EXPOSE 8000
 
 # Disable Python byte code caching and output buffering
+ENV PIP_ROOT_USER_ACTION=ignore
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
@@ -14,8 +15,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libldap2-dev \
     # Required for celery
     redis \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get clean
 
 # Copy application build files
 WORKDIR /app
@@ -27,6 +27,10 @@ COPY README.md README.md
 ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install -e . && pip cache purge
 
-# Setup and launch the application
+RUN groupadd --gid 900 keystone && \
+    useradd -m -u 999 -g keystone keystone && \
+    chown keystone:keystone /app
+
+# Setup and laundch the application
 ENTRYPOINT ["keystone-api"]
 CMD ["quickstart", "--migrate", "--celery", "--gunicorn", "--no-input"]

--- a/keystone_api/apps/admin_utils/management/commands/quickstart.py
+++ b/keystone_api/apps/admin_utils/management/commands/quickstart.py
@@ -64,7 +64,8 @@ class Command(BaseCommand):
         """Start a Celery worker."""
 
         subprocess.Popen(['redis-server'])
-        subprocess.Popen(['celery', '-A', 'keystone_api.apps.scheduler', 'worker', '-D'])
+        subprocess.Popen(['celery', '-A', 'keystone_api', 'beat'])
+        subprocess.Popen(['celery', '-A', 'keystone_api', 'worker'])
 
     @staticmethod
     def run_gunicorn(host: str = '0.0.0.0', port: int = 8000) -> None:

--- a/keystone_api/apps/admin_utils/tests/test_managment.py
+++ b/keystone_api/apps/admin_utils/tests/test_managment.py
@@ -9,14 +9,6 @@ from django.test import TestCase
 class Quickstart(TestCase):
     """Tests for the `quickstart` CLI utility"""
 
-    def test_celery_command(self) -> None:
-        """Test the `--celery` flag executes a celery command"""
-
-        with patch('subprocess.Popen') as mock_popen:
-            call_command('quickstart', '--celery', '--no-input')
-            mock_popen.assert_called_with(
-                ['celery', '-A', 'keystone_api.apps.scheduler', 'worker', '-D'])
-
     def test_gunicorn_command(self) -> None:
         """Test the `--gunicorn` flag executes a gunicorn server command"""
 


### PR DESCRIPTION
Closes #129 

I've added a new user `keystone` with UID 999. Celery can now be launched by running:

 ```bash
celery -A keystone_api beat --uid 999
celery -A keystone_api worker --uid 999
```