### PR TITLE
Switch from env.str to os.environ.get for secret key

### DIFF
--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -24,7 +24,7 @@ FIXTURE_DIRS = [BASE_DIR / 'tests' / 'fixtures']
 
 # Core security settings
 
-SECRET_KEY = env.str('SECURE_SECRET_KEY', 'key-' + get_random_secret_key())
+SECRET_KEY = 'key-' + env.str('SECURE_SECRET_KEY', get_random_secret_key())
 ALLOWED_HOSTS = env.list("SECURE_ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
 
 _SECURE_SESSION_TOKENS = env.bool("SECURE_SESSION_TOKENS", default=False)

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -1,6 +1,7 @@
 """Top level Django application settings."""
 
 import importlib.metadata
+import os
 import sys
 from pathlib import Path
 
@@ -24,7 +25,7 @@ FIXTURE_DIRS = [BASE_DIR / 'tests' / 'fixtures']
 
 # Core security settings
 
-SECRET_KEY = 'key-' + env.str('SECURE_SECRET_KEY', get_random_secret_key())
+SECRET_KEY = os.environ.get('SECURE_SECRET_KEY', get_random_secret_key())
 ALLOWED_HOSTS = env.list("SECURE_ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
 
 _SECURE_SESSION_TOKENS = env.bool("SECURE_SESSION_TOKENS", default=False)


### PR DESCRIPTION
Original issue #125
Related PR #128

PR 128 fixed the recursion error for randomly generated keys, but not for manually specified keys. This was a simple human oversight an is fixed in this PR.