### PR TITLE
Adds support for loading user data from ldap

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,19 @@ Limits are specified as the maximum number of requests per `day`, `minute`, `hou
 | `API_THROTTLE_ANON`       | `1000/day`               | Rate limiting for anonymous (unauthenticated) users.          |
 | `API_THROTTLE_USER`       | `10000/day`              | Rate limiting for authenticated users.                        |
 
-### Authentication
+### LDAP Authentication
 
 Enabling LDAP authentication is optional and disabled by default.
 To enable LDAP, set the `AUTH_LDAP_SERVER_URI` value to the desired LDAP endpoint.
+
+Application user fields can be mapped to LDAP attributes by specifying the `AUTH_LDAP_ATTR_MAP` setting.
+The following example maps the `first_name` and `last_name` fields used by Keystone to the LDAP attributes `givenName` and `sn`:
+
+```bash
+AUTH_LDAP_ATTR_MAP="first_name=givenName,last_name=sn"
+```
+
+See the `apps.users.models.User` class for a full list of available Keystone fields.
 
 | Setting Name              | Default Value            | Description                                                   |
 |---------------------------|--------------------------|---------------------------------------------------------------|
@@ -145,6 +154,7 @@ To enable LDAP, set the `AUTH_LDAP_SERVER_URI` value to the desired LDAP endpoin
 | `AUTH_LDAP_BIND_PASSWORD` |                          | The password to use when binding to the LDAP server.          |
 | `AUTH_LDAP_USER_SEARCH`   | `(uid=%(user)s)`         | The search query for finding a user in the LDAP server.       |
 | `AUTH_LDAP_REQUIRE_CERT`  | `False`                  | Whether to require certificate verification.                  |
+| `AUTH_LDAP_ATTR_MAP`      |                          | A mapping of user fields to LDAP attribute names.             |
 
 ### Database Connection
 

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -220,6 +220,9 @@ if AUTH_LDAP_SERVER_URI := env.url("AUTH_LDAP_SERVER_URI", "").geturl():
     if env.bool('AUTH_LDAP_REQUIRE_CERT', False):
         AUTH_LDAP_GLOBAL_OPTIONS = {ldap.OPT_X_TLS_REQUIRE_CERT: ldap.OPT_X_TLS_NEVER}
 
+    if _AUTH_LDAP_ATTR_MAP := env.dict('AUTH_LDAP_ATTR_MAP'):
+        AUTH_LDAP_USER_ATTR_MAP = _AUTH_LDAP_ATTR_MAP
+
 AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
     {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator'},


### PR DESCRIPTION
This PR adds the `AUTH_LDAP_ATTR_MAP` setting which allows Keystone user fields to be mapped to LDAP attributes.

Closes #179