### PR TITLE
Fix timezone warning when running test suite

### DIFF
--- a/keystone_api/tests/fixtures/multi_research_group.yaml
+++ b/keystone_api/tests/fixtures/multi_research_group.yaml
@@ -130,7 +130,7 @@
     approve: true
     request: 1
     reviewer: 9
-    date_modified: "2023-01-01"
+    date_modified: "2023-01-01T12:00:00Z"
 
 # Allocations
 - model: allocations.allocation


### PR DESCRIPTION
One of the test fixtures was passing a naive datetime to a timezone aware model.