### PR TITLE
Removes residual traces of the auditlog app

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ Running the application in debug mode enables/disables various features to aid i
 In addition to enabling the standard debugging behavior provided by Django:
 
 - A `/docs` page is enabled with full API documentation for the parent application
-- A web GUI is enabled for easier interaction with API endpoints
 - Tracebacks are provided in the browser when an exception occurs (a Django standard)
 
 ### Tests and System Checks

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -67,7 +67,6 @@ INSTALLED_APPS = [
     'django_celery_results',
     'django_filters',
     'drf_spectacular',
-    'auditlog',
     'apps.admin_utils',
     'apps.allocations',
     'apps.docs',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ keystone-api = "keystone_api.manage:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 django = "4.2.11"
-django-auditlog = "2.3.0"
 django-auth-ldap = "4.6.0"
 django-celery-beat = "2.6.0"
 django-celery-results = "2.5.1"


### PR DESCRIPTION
The `audit` app was removed in an earlier PR, but it looks like I missed a few dependencies/settings. 