### PR TITLE
Adds Codacy to QA CI

### DIFF
--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -15,6 +15,7 @@ jobs:
 
   qa:
     name: QA
+    needs: build
     uses: ./.github/workflows/QA.yml
     secrets: inherit
 

--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -16,6 +16,7 @@ jobs:
   qa:
     name: QA
     uses: ./.github/workflows/QA.yml
+    secrets: inherit
 
   report-pr-status:
     name: Report PR Status

--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -27,5 +27,5 @@ jobs:
 
     steps:
       - name: Check PR status
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/.github/workflows/QA.yml
+++ b/.github/workflows/QA.yml
@@ -47,5 +47,5 @@ jobs:
 
     steps:
       - name: Check QA status
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/.github/workflows/QA.yml
+++ b/.github/workflows/QA.yml
@@ -42,7 +42,7 @@ jobs:
   report-qa-status:
     name: Report QA Status
     runs-on: ubuntu-latest
-    needs: [ codeql ]
+    needs: [ codeql, codacy ]
     if: always()
 
     steps:

--- a/.github/workflows/QA.yml
+++ b/.github/workflows/QA.yml
@@ -26,6 +26,19 @@ jobs:
         with:
           category: /language:python
 
+  codacy:
+    name: Codacy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@master
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          upload: true
+
   report-qa-status:
     name: Report QA Status
     runs-on: ubuntu-latest

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -79,5 +79,5 @@ jobs:
 
     steps:
       - name: Check test status
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/.github/workflows/UpdatedMain.yml
+++ b/.github/workflows/UpdatedMain.yml
@@ -9,3 +9,4 @@ jobs:
   qa:
     name: QA
     uses: ./.github/workflows/QA.yml
+    secrets: inherit


### PR DESCRIPTION
This PR makes a few changes to the CI:
1. Codacy is added to the QA CI
2. Cancelled jobs are considered as failed by the report status steps
3. The order of the CI as been generalized so that builds happen before everything else

Change #3 adds about a minute to the CI but (for the time being) I think the clarity is worth it.