### PR TITLE
Fixes bug where default the defult task schdule is ignored.

### DIFF
--- a/keystone_api/apps/scheduler/celery.py
+++ b/keystone_api/apps/scheduler/celery.py
@@ -7,7 +7,19 @@ with the Celery application instance for all applications defined in the
 """
 
 from celery import Celery
+from celery.schedules import crontab
 
 celery_app = Celery("scheduler")
 celery_app.config_from_object("django.conf:settings", namespace="CELERY")
 celery_app.autodiscover_tasks()
+
+celery_app.conf.beat_schedule = {
+    "Update LDAP users": {
+        "task": "apps.users.tasks.ldap_update_users",
+        "schedule": crontab(minute='0'),
+    },
+    "Rotate Log Entries": {
+        "task": "apps.logging.tasks.rotate_log_files",
+        "schedule": crontab(hour='0', minute='0'),
+    }
+}

--- a/keystone_api/apps/scheduler/celery.py
+++ b/keystone_api/apps/scheduler/celery.py
@@ -9,17 +9,19 @@ with the Celery application instance for all applications defined in the
 from celery import Celery
 from celery.schedules import crontab
 
-celery_app = Celery("scheduler")
-celery_app.config_from_object("django.conf:settings", namespace="CELERY")
+celery_app = Celery('scheduler')
+celery_app.config_from_object('django.conf:settings', namespace='CELERY')
 celery_app.autodiscover_tasks()
 
 celery_app.conf.beat_schedule = {
-    "Update LDAP users": {
-        "task": "apps.users.tasks.ldap_update_users",
-        "schedule": crontab(minute='0'),
+    'apps.users.tasks.ldap_update_users': {
+        'task': 'apps.users.tasks.ldap_update_users',
+        'schedule': crontab(minute='0'),
+        'description': 'This task synchronizes user data against LDAP. If LDAP authentication is not bing used, this task does nothing.'
     },
-    "Rotate Log Entries": {
-        "task": "apps.logging.tasks.rotate_log_files",
-        "schedule": crontab(hour='0', minute='0'),
+    'apps.logging.tasks.rotate_log_files': {
+        'task': 'apps.logging.tasks.rotate_log_files',
+        'schedule': crontab(hour='0', minute='0'),
+        'description': 'This task deletes old log entries according to application settings.'
     }
 }

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -172,7 +172,7 @@ CELERY_RESULT_BACKEND = 'django-db'
 CELERY_CACHE_BACKEND = 'django-cache'
 CELERY_BEAT_SCHEDULE = {
     "Update LDAP users": {
-        "task": "apps.users.tasks.ldap_update",
+        "task": "apps.users.tasks.ldap_update_users",
         "schedule": crontab(minute='0'),
     },
     "Rotate Log Entries": {

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -7,7 +7,6 @@ from datetime import timedelta
 from pathlib import Path
 
 import environ
-from celery.schedules import crontab
 from django.core.management.utils import get_random_secret_key
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -166,20 +165,10 @@ _redis_db = env.int('REDIS_DB', 0)
 _redis_pass = env.str('REDIS_PASSWORD', '')
 
 REDIS_URL = f'redis://:{_redis_pass}@{_redis_host}:{_redis_port}'
-CELERY_BROKER_URL = REDIS_URL + f'/{_redis_db}'
 
+CELERY_BROKER_URL = REDIS_URL + f'/{_redis_db}'
 CELERY_RESULT_BACKEND = 'django-db'
 CELERY_CACHE_BACKEND = 'django-cache'
-CELERY_BEAT_SCHEDULE = {
-    "Update LDAP users": {
-        "task": "apps.users.tasks.ldap_update_users",
-        "schedule": crontab(minute='0'),
-    },
-    "Rotate Log Entries": {
-        "task": "apps.logging.tasks.rotate_log_files",
-        "schedule": crontab(hour='0', minute='0'),
-    }
-}
 
 # Database
 


### PR DESCRIPTION
closes #225 

I fixed the issue by moving the celery beat schedule out of the `main.settings` module and directly into the `apps.scheduler.celery` module. It would be nice to have all of the configuration in one place, but after referencing the official docs and trying several failed approaches in the settings file, this approach seems much more stable.

@Comeani This is also a good reminder to both of us to be careful when renaming tasks. It looks like in #198 the task name was updated but we both forgot to check for references to the tasks signature.