### PR TITLE
Fixes 500 error raised by `users/users/` endpoint

### DIFF
--- a/keystone_api/apps/users/views.py
+++ b/keystone_api/apps/users/views.py
@@ -35,6 +35,7 @@ class ResearchGroupViewSet(viewsets.ModelViewSet):
 class UserViewSet(viewsets.ModelViewSet):
     """Read only access to user datta."""
 
+    queryset = User.objects.all()
     permission_classes = [permissions.IsAuthenticated, StaffWriteAuthenticatedRead]
     serializer_class = UserSerializer
     filterset_fields = '__all__'


### PR DESCRIPTION
The ViewSet for `/users/users/` did not have a queryset defined which caused HTTP requests to fail with a 500 error. Perhaps more importantly, the tests for this endpoint were missing an `__init__.py` file in their parent folder causing Django (and the CI) to skip the tests, letting the bug go undetected. 

Pinging @Comeani so he is aware of the fix.