### PR TITLE
Adds a system check for validating the Celery entrypoint

### DIFF
--- a/keystone_api/apps/scheduler/apps.py
+++ b/keystone_api/apps/scheduler/apps.py
@@ -1,0 +1,22 @@
+"""Application configuration and initialization logic.
+
+Subclasses of the Django `AppConfig` class are automatically loaded by Django
+and used to initialize the parent application. This includes encapsulating
+startup tasks and configuring how the application integrates with the framework.
+"""
+
+from django.apps import AppConfig
+from django.core.checks import register
+
+from .checks import *
+
+
+class SchedulerConfig(AppConfig):
+    """Configure the parent application"""
+
+    name = 'apps.scheduler'
+
+    def ready(self):
+        """Executed once the as the Django application registry is fully populated."""
+
+        register(check_celery_is_importable)

--- a/keystone_api/apps/scheduler/apps.py
+++ b/keystone_api/apps/scheduler/apps.py
@@ -17,6 +17,6 @@ class SchedulerConfig(AppConfig):
     name = 'apps.scheduler'
 
     def ready(self):
-        """Executed once the as the Django application registry is fully populated."""
+        """Executed as soon as the Django application registry is fully populated."""
 
         register(check_celery_is_importable)

--- a/keystone_api/apps/scheduler/checks.py
+++ b/keystone_api/apps/scheduler/checks.py
@@ -1,8 +1,8 @@
 """System checks for verifying proper application configuration.
 
-System checks extend Django's built-in inspection framework. Checks are used
-to inspect the state and configuration of the parent application and raise
-an exception when errors are found.
+System checks are used to report configuration errors in the parent
+application. See the `apps.py` file for their registration with the
+Django System Checks framework.
 """
 
 from django.core.checks import Error

--- a/keystone_api/apps/scheduler/checks.py
+++ b/keystone_api/apps/scheduler/checks.py
@@ -1,0 +1,32 @@
+"""System checks for verifying proper application configuration.
+
+System checks extend Django's built-in inspection framework. Checks are used
+to inspect the state and configuration of the parent application and raise
+an exception when errors are found.
+"""
+
+from django.core.checks import Error
+
+import keystone_api
+
+__all__ = ['check_celery_is_importable']
+
+
+def check_celery_is_importable(app_configs, **kwargs):
+    """Check the `` variable is importable from the top level package"""
+
+    errors = []
+    try:
+        from keystone_api import celery_app
+
+    except ImportError:
+        errors.append(
+            Error(
+                "missing `celery_app` variable",
+                hint="Make sure the `celery_app` variable is importable from the top level package.",
+                id="apps.scheduler.E001",
+                obj=keystone_api
+            )
+        )
+
+    return errors


### PR DESCRIPTION
This project has had trouble getting Celery configured correctly. The new system check ensures the `celery_app` app is importable from `keystone_api`, mostly to protect well meaning developers from themselves.