### PR TITLE
Adds advanced query functionality for model fields via REST API params

### DIFF
--- a/keystone_api/apps/allocations/views.py
+++ b/keystone_api/apps/allocations/views.py
@@ -24,13 +24,6 @@ class AllocationViewSet(viewsets.ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, StaffWriteGroupRead]
     serializer_class = AllocationSerializer
-    filterset_fields = {
-        'requested': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
-        'awarded': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
-        'final': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
-        'cluster': ['exact', 'in'],
-        'request': ['exact', 'in'],
-    }
 
     def get_queryset(self) -> list[Allocation]:
         """Return a list of allocations for the currently authenticated user"""
@@ -46,15 +39,6 @@ class AllocationRequestViewSet(viewsets.ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, GroupAdminCreateGroupRead]
     serializer_class = AllocationRequestSerializer
-    filterset_fields = {
-        'title': ['exact', 'in', 'contains', 'icontains'],
-        'description': ['exact', 'in', 'contains', 'icontains'],
-        'submitted': ['exact', 'in', 'contains', 'icontains'],
-        'status': ['exact', 'in'],
-        'active': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
-        'expire': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
-        'group': ['exact', 'in'],
-    }
 
     def get_queryset(self) -> list[AllocationRequest]:
         """Return a list of allocation requests for the currently authenticated user"""
@@ -70,14 +54,6 @@ class AllocationRequestReviewViewSet(viewsets.ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, StaffWriteGroupRead]
     serializer_class = AllocationRequestReviewSerializer
-    filterset_fields = {
-        'status': ['exact', 'in'],
-        'public_comments': ['exact', 'in', 'contains', 'icontains'],
-        'private_comments': ['exact', 'in', 'contains', 'icontains'],
-        'date_modified': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
-        'request': ['exact', 'in'],
-        'reviewer': ['exact', 'in'],
-    }
 
     def get_queryset(self) -> list[Allocation]:
         """Return a list of allocation reviews for the currently authenticated user"""
@@ -107,8 +83,3 @@ class ClusterViewSet(viewsets.ModelViewSet):
     queryset = Cluster.objects.all()
     permission_classes = [permissions.IsAuthenticated, StaffWriteAuthenticatedRead]
     serializer_class = ClusterSerializer
-    filterset_fields = {
-        'name': ['exact', 'in', 'contains', 'icontains'],
-        'description': ['exact', 'in', 'contains', 'icontains'],
-        'enabled': ['exact', 'in'],
-    }

--- a/keystone_api/apps/allocations/views.py
+++ b/keystone_api/apps/allocations/views.py
@@ -24,7 +24,13 @@ class AllocationViewSet(viewsets.ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, StaffWriteGroupRead]
     serializer_class = AllocationSerializer
-    filterset_fields = '__all__'
+    filterset_fields = {
+        'requested': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
+        'awarded': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
+        'final': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
+        'cluster': ['exact', 'in'],
+        'request': ['exact', 'in'],
+    }
 
     def get_queryset(self) -> list[Allocation]:
         """Return a list of allocations for the currently authenticated user"""
@@ -40,7 +46,15 @@ class AllocationRequestViewSet(viewsets.ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, GroupAdminCreateGroupRead]
     serializer_class = AllocationRequestSerializer
-    filterset_fields = '__all__'
+    filterset_fields = {
+        'title': ['exact', 'in', 'contains', 'icontains'],
+        'description': ['exact', 'in', 'contains', 'icontains'],
+        'submitted': ['exact', 'in', 'contains', 'icontains'],
+        'status': ['exact', 'in'],
+        'active': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
+        'expire': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
+        'group': ['exact', 'in'],
+    }
 
     def get_queryset(self) -> list[AllocationRequest]:
         """Return a list of allocation requests for the currently authenticated user"""
@@ -56,7 +70,14 @@ class AllocationRequestReviewViewSet(viewsets.ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, StaffWriteGroupRead]
     serializer_class = AllocationRequestReviewSerializer
-    filterset_fields = '__all__'
+    filterset_fields = {
+        'status': ['exact', 'in'],
+        'public_comments': ['exact', 'in', 'contains', 'icontains'],
+        'private_comments': ['exact', 'in', 'contains', 'icontains'],
+        'date_modified': ['exact', 'in', 'lt', 'lte', 'gt', 'gte'],
+        'request': ['exact', 'in'],
+        'reviewer': ['exact', 'in'],
+    }
 
     def get_queryset(self) -> list[Allocation]:
         """Return a list of allocation reviews for the currently authenticated user"""
@@ -86,4 +107,8 @@ class ClusterViewSet(viewsets.ModelViewSet):
     queryset = Cluster.objects.all()
     permission_classes = [permissions.IsAuthenticated, StaffWriteAuthenticatedRead]
     serializer_class = ClusterSerializer
-    filterset_fields = '__all__'
+    filterset_fields = {
+        'name': ['exact', 'in', 'contains', 'icontains'],
+        'description': ['exact', 'in', 'contains', 'icontains'],
+        'enabled': ['exact', 'in'],
+    }

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -145,7 +145,7 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
     ],
     'DEFAULT_FILTER_BACKENDS': (
-        'plugins.filter.BackendFilter',
+        'plugins.filter.AdvancedFilterBackend',
     ),
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }

--- a/keystone_api/main/settings.py
+++ b/keystone_api/main/settings.py
@@ -145,7 +145,7 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
     ],
     'DEFAULT_FILTER_BACKENDS': (
-        'django_filters.rest_framework.DjangoFilterBackend',
+        'plugins.filter.BackendFilter',
     ),
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }

--- a/keystone_api/plugins/filter.py
+++ b/keystone_api/plugins/filter.py
@@ -18,7 +18,7 @@ class BackendFilter(DjangoFilterBackend):
     _numeric_filters = _default_filters + ['exact', 'in', 'lt', 'lte', 'gt', 'gte']
     _text_filters = _default_filters + ['exact', 'iexact', 'contains', 'icontains', 'startswith', 'istartswith', 'endswith', 'iendswith']
     _date_filters = _default_filters + ['year', 'month', 'day', 'week', 'week_day']
-    _time_filters = _default_filters + ['hout', 'minute', 'second']
+    _time_filters = _default_filters + ['hour', 'minute', 'second']
 
     _field_filter_map = {
         fields.AutoField: _numeric_filters,

--- a/keystone_api/plugins/filter.py
+++ b/keystone_api/plugins/filter.py
@@ -58,7 +58,7 @@ class BackendFilter(DjangoFilterBackend):
              field: A Django model field
 
          Returns:
-             List of filter types applicable to the given field
+             A list of filter types applicable to the given field
          """
 
         return self._field_filter_map.get(type(field), self._default_filters)

--- a/keystone_api/plugins/filter.py
+++ b/keystone_api/plugins/filter.py
@@ -15,10 +15,10 @@ class AdvancedFilterBackend(DjangoFilterBackend):
     """
 
     _default_filters = ['exact', 'in', 'isnull']
-    _numeric_filters = _default_filters + ['exact', 'in', 'lt', 'lte', 'gt', 'gte']
-    _text_filters = _default_filters + ['exact', 'iexact', 'contains', 'icontains', 'startswith', 'istartswith', 'endswith', 'iendswith']
-    _date_filters = _default_filters + ['year', 'month', 'day', 'week', 'week_day']
-    _time_filters = _default_filters + ['hour', 'minute', 'second']
+    _numeric_filters = _default_filters + ['lt', 'lte', 'gt', 'gte']
+    _text_filters = _default_filters + ['contains', 'startswith', 'endswith']
+    _date_filters = _default_filters + _numeric_filters + ['year', 'month', 'day', 'week', 'week_day']
+    _time_filters = _default_filters + _numeric_filters + ['hour', 'minute', 'second']
 
     _field_filter_map = {
         models.AutoField: _numeric_filters,
@@ -28,7 +28,7 @@ class AdvancedFilterBackend(DjangoFilterBackend):
         models.CharField: _text_filters,
         models.CommaSeparatedIntegerField: _default_filters,
         models.DateField: _date_filters,
-        models.DateTimeField: _date_filters + _time_filters,
+        models.DateTimeField: list(set(_date_filters + _time_filters)),
         models.DecimalField: _numeric_filters,
         models.DurationField: _default_filters,
         models.EmailField: _text_filters,

--- a/keystone_api/plugins/filter.py
+++ b/keystone_api/plugins/filter.py
@@ -1,0 +1,87 @@
+"""Extends the `django-filter` package with custom filter backends.
+
+Filter backends define the default behavior when filtering database queries
+for REST API calls based on URL parameters.
+"""
+
+from django.db.models import fields
+from django_filters.rest_framework import DjangoFilterBackend
+
+
+class BackendFilter(DjangoFilterBackend):
+    """Custom filter backend for Django REST framework
+
+    This filter backend automatically generates filters for Django model fields based on their types.
+    """
+
+    _default_filters = ['exact', 'in', 'isnull']
+    _numeric_filters = _default_filters + ['exact', 'in', 'lt', 'lte', 'gt', 'gte']
+    _text_filters = _default_filters + ['exact', 'iexact', 'contains', 'icontains', 'startswith', 'istartswith', 'endswith', 'iendswith']
+    _date_filters = _default_filters + ['year', 'month', 'day', 'week', 'week_day']
+    _time_filters = _default_filters + ['hout', 'minute', 'second']
+
+    _field_filter_map = {
+        fields.AutoField: _numeric_filters,
+        fields.BigAutoField: _numeric_filters,
+        fields.BigIntegerField: _numeric_filters,
+        fields.BinaryField: _default_filters,
+        fields.BooleanField: _default_filters,
+        fields.CharField: _text_filters,
+        fields.CommaSeparatedIntegerField: _default_filters,
+        fields.DateField: _date_filters,
+        fields.DateTimeField: _date_filters + _time_filters,
+        fields.DecimalField: _numeric_filters,
+        fields.DurationField: _default_filters,
+        fields.EmailField: _text_filters,
+        fields.FilePathField: _text_filters,
+        fields.FloatField: _numeric_filters,
+        fields.GenericIPAddressField: _default_filters,
+        fields.IPAddressField: _default_filters,
+        fields.IntegerField: _numeric_filters,
+        fields.NullBooleanField: _default_filters,
+        fields.PositiveBigIntegerField: _numeric_filters,
+        fields.PositiveIntegerField: _numeric_filters,
+        fields.PositiveSmallIntegerField: _numeric_filters,
+        fields.SlugField: _text_filters,
+        fields.SmallAutoField: _numeric_filters,
+        fields.SmallIntegerField: _numeric_filters,
+        fields.TextField: _text_filters,
+        fields.TimeField: _time_filters,
+        fields.URLField: _text_filters,
+        fields.UUIDField: _default_filters
+    }
+
+    def get_filter_type(self, field: fields.Field) -> list[str]:
+        """Get the appropriate filter types for a given field type
+
+         Args:
+             field: A Django model field
+
+         Returns:
+             List of filter types applicable to the given field
+         """
+
+        return self._field_filter_map.get(type(field), self._default_filters)
+
+    def get_filterset_class(self, view, queryset=None):
+        """Get the filterSet class for a given view
+
+        Args:
+            view: The view instance
+            queryset: The queryset for the view
+
+        Returns:
+            A FilterSet class
+        """
+
+        # Default to user provided filterset class
+        # Super method returns `None` if not defined
+        if filterset_class := super().get_filterset_class(view, queryset=queryset):
+            return filterset_class
+
+        class AutoFilterSet(self.filterset_base):
+            class Meta:
+                model = queryset.model
+                fields = {field.name: self.get_filter_type(field) for field in queryset.model._meta.get_fields()}
+
+        return AutoFilterSet


### PR DESCRIPTION
Close #277 

Keystone implements API query filtering via the `django-filter` package. The third party package is capable of advanced query operations, but it only enables equality comparisons by default. Additional operations can be added manually on a per-field basis, but that gets redundant very quickly. Instead, I've implemented a custom filter back end that redefines the default query operations enabled for each field type.

## Query Expressions

API queries support filtering via URL parameters. 
For example, the following API call limit the returned records to those where the `count` field equals `100`:

```
my.domain.com/endpoint?count=100
```

More advanced filtering is achieved by adding query filters.
The following API call will return records when the `count` field is less than `100`:

```
my.domain.com/endpoint?count=100
```

Note: You cannot chain together query filters. 


### General Filters

The following filters are available for all data types.

| Query Expression | Description | Example |
|------------------|-------------|---------|
| `in`             |  Whether the value is in a comma-separated list of values           | `field__in=1,2,3` |
| `isnull`         |  Whether the value is none           | `field__isnull=true` |

### Numeric Filters

The following filters are available for numerical data such as floats and integers.

| Query Expression | Description | Example |
|------------------|-------------|---------|
| `lt`             |  Whether the value is less than another value           | `field__lt=100` |
| `lte`            |  Whether the value is less than or equal to another value           | `field__lte=100` |
| `gt`             |  Whether the value is greater than another value           | `field__gt=100` |
| `gte`            |  Whether the value is greater than or equal to another value           | `field__gte=100` |
 
### String Filters

The following filters are available for text and character values.

| Query Expression | Description | Example |
|------------------|-------------|---------|
| `contains`       | Whether the value contains subtext            | `field__contains=subtext` |
| `startswith`     |  Whether the value starts with the given text           | `field__startswith=subtext` |
| `endswith`       |   Whether the value ends with the given text           | `field__endswith=subtext` |

### Date Filters

The following filters are available for date and datetime values in ISO-8601 format.

| Query Expression | Description | Example |
|------------------|-------------|---------|
| `year`           |   Whether the date value matches a given year           | `field__year=2022` |
| `month`          |  Whether the date value matches a given month           | `field__month=12` |
| `day`            |    Whether the date value matches a given day         | `field__day=25` |
| `week`           |   Whether the date value falls on a given week of the month          | `field__week=52` |
| `week_day`       |  Whether the date value falls a given day of the week            | `field__week_day=1` |
| `lt`             |  Whether the value is less than another value           | `field__lt=2020-01-22`  |
| `lte`            |  Whether the value is less than or equal to another value           | `field__lte=2020-01-22` |
| `gt`             |  Whether the value is greater than another value           | `field__gt=2020-01-22` |
| `gte`            |  Whether the value is greater than or equal to another value           | `field__gte=2020-01-22`  |

### Time Filters

The following filters are available for time and datetime values in ISO-8601 format.

| Query Expression | Description | Example |
|------------------|-------------|---------|
| `hour`           |  Whether the time value matches a given hour           | `field__hour=8` |
| `minute`         |  Whether the time value matches a given minute            | `field__minute=30` |
| `second`         |   Whether the time value matches a given second           | `field__second=45` | 
| `lt`             |  Whether the value is less than another value           |  `field__lt=19:20:15`  |
| `lte`            |  Whether the value is less than or equal to another value           | `field__lte=19:20:15`  |
| `gt`             |  Whether the value is greater than another value           | `field__gt=19:20:15`  |
| `gte`            |  Whether the value is greater than or equal to another value           |`field__gte=19:20:15`  |
