### PR TITLE
Removes filterset_fields definitions

### DIFF
--- a/keystone_api/apps/logging/views.py
+++ b/keystone_api/apps/logging/views.py
@@ -17,7 +17,6 @@ class AppLogViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = AppLog.objects.all()
     serializer_class = AppLogSerializer
-    filterset_fields = '__all__'
     permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser]
 
 
@@ -26,7 +25,6 @@ class RequestLogViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = RequestLog.objects.all()
     serializer_class = RequestLogSerializer
-    filterset_fields = '__all__'
     permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser]
 
 
@@ -35,5 +33,4 @@ class TaskResultViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = TaskResult.objects.all()
     serializer_class = TaskResultSerializer
-    filterset_fields = '__all__'
     permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser]

--- a/keystone_api/apps/research_products/views.py
+++ b/keystone_api/apps/research_products/views.py
@@ -18,7 +18,6 @@ class PublicationViewSet(viewsets.ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser | GroupMemberAll]
     serializer_class = PublicationSerializer
-    filterset_fields = '__all__'
 
     def get_queryset(self) -> list[Publication]:
         """Return a list of allocation requests for the currently authenticated user"""
@@ -34,7 +33,6 @@ class GrantViewSet(viewsets.ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser | GroupMemberReadGroupAdminWrite]
     serializer_class = GrantSerializer
-    filterset_fields = '__all__'
 
     def get_queryset(self) -> list[Grant]:
         """Return a list of allocation requests for the currently authenticated user"""

--- a/keystone_api/apps/users/views.py
+++ b/keystone_api/apps/users/views.py
@@ -21,7 +21,6 @@ class ResearchGroupViewSet(viewsets.ModelViewSet):
 
     permission_classes = [permissions.IsAuthenticated, StaffWriteAuthenticatedRead]
     serializer_class = ResearchGroupSerializer
-    filterset_fields = '__all__'
 
     def get_queryset(self) -> list[ResearchGroup]:
         """Return a list of all research groups to admins, or the requesting users research groups"""
@@ -38,4 +37,3 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     permission_classes = [permissions.IsAuthenticated, StaffWriteAuthenticatedRead]
     serializer_class = UserSerializer
-    filterset_fields = '__all__'


### PR DESCRIPTION
The `filterset_fields` variable is no longer required on API View classes as of #277 