### PR TITLE
Include foreign keys in filter map 

### DIFF
--- a/keystone_api/plugins/filter.py
+++ b/keystone_api/plugins/filter.py
@@ -34,7 +34,7 @@ class AdvancedFilterBackend(DjangoFilterBackend):
         models.EmailField: _text_filters,
         models.FilePathField: _text_filters,
         models.FloatField: _numeric_filters,
-        models.ForeignKey: _numeric_filters,
+        models.ForeignKey: _default_filters,
         models.GenericIPAddressField: _default_filters,
         models.IPAddressField: _default_filters,
         models.IntegerField: _numeric_filters,

--- a/keystone_api/plugins/filter.py
+++ b/keystone_api/plugins/filter.py
@@ -34,6 +34,7 @@ class AdvancedFilterBackend(DjangoFilterBackend):
         models.EmailField: _text_filters,
         models.FilePathField: _text_filters,
         models.FloatField: _numeric_filters,
+        models.ForeignKey: _numeric_filters,
         models.GenericIPAddressField: _default_filters,
         models.IPAddressField: _default_filters,
         models.IntegerField: _numeric_filters,


### PR DESCRIPTION
Using `group` pk as a query param when gathering relevant `AllocationRequest`s from keystone is not working properly in the wrappers. 

This change fixes that by explicitly defining `models.ForeignKey` the the filter map defined in the recently introduced `AdvancedFilterBackend` constructing the `FilterSet` for any given view.