### PR TITLE
Drops redundant docs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,23 +1,4 @@
 site_name: Keystone API
-theme:
-  name: material
-  features:
-    - navigation.sections
-    - content.code.annotate
-    - content.tabs.link
-plugins:
-  - render_swagger:
-      allow_arbitrary_locations : true
-markdown_extensions:
-  - admonition
-  - attr_list
-  - md_in_html
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  - pymdownx.superfences
-  - pymdownx.tabbed:
-      alternate_style: true
 nav:
   - index.md
   - Installation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,7 @@ whitenoise = "6.6.0"
 
 # Optional dependencies installed via extras
 django-auth-ldap = { version = "4.8.0", optional = true }
-mkdocs-material = { version = "^9.5.17", optional = true }
-mkdocs-render-swagger-plugin = { version = "^0.1.1", optional = true }
-
 
 [tool.poetry.extras]
 ldap = ["django-auth-ldap"]
-docs = ["mkdocs-material", "mkdocs-render-swagger-plugin"]
-all = ["django-auth-ldap", "mkdocs-material", "mkdocs-render-swagger-plugin"]
+all = ["django-auth-ldap"]


### PR DESCRIPTION
Documentation is now being fully rendered under the [keystone-docs](https://github.com/pitt-crc/keystone-docs) repo. The extra dependencies and Mkdocs settings are no longer needed in this repository.