### PR TITLE
`User` First/Last name and email as optional fields

### DIFF
--- a/keystone_api/apps/users/models.py
+++ b/keystone_api/apps/users/models.py
@@ -21,7 +21,6 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
 
     USERNAME_FIELD = 'username'
     EMAIL_FIELD = "email"
-    REQUIRED_FIELDS = ['username']
 
     username = models.CharField('username', max_length=150, unique=True, validators=[UnicodeUsernameValidator()])
     first_name = models.CharField('first name', max_length=150)

--- a/keystone_api/apps/users/models.py
+++ b/keystone_api/apps/users/models.py
@@ -21,7 +21,7 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
 
     USERNAME_FIELD = 'username'
     EMAIL_FIELD = "email"
-    REQUIRED_FIELDS = ['email', 'first_name', 'last_name']
+    REQUIRED_FIELDS = ['username']
 
     username = models.CharField('username', max_length=150, unique=True, validators=[UnicodeUsernameValidator()])
     first_name = models.CharField('first name', max_length=150)


### PR DESCRIPTION
The intention of this PR is to remove first/last name and email as required fields in the `User` model as to simplify POST requests upon new user creation with our admin scripts.

Eventually we will retain this info in LDAP, and updating the info in Keystone will be left to the hourly task syncing against that.