### PR TITLE
Adds missing `needs` dependency when calling publish job on release

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -36,7 +36,7 @@ jobs:
   
   publish:
     name: Publish
-    needs: test
+    needs: [ version, test ]
     uses: ./.github/workflows/Publish.yml
     secrets: inherit
     with:


### PR DESCRIPTION
This should address https://github.com/pitt-crc/keystone-docs/issues/9.

The `publish.with.version` value relies on `needs.version.outputs.version` but the `version` job is missing from the `needs` list.