### PR TITLE
Drops cache from image publication

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -51,8 +51,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64,linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   publish-pypi:
     name: Python Distribution


### PR DESCRIPTION
See failed publish step in https://github.com/pitt-crc/keystone-api/actions/runs/9959830007